### PR TITLE
feat: implement documented backend api

### DIFF
--- a/agente.md
+++ b/agente.md
@@ -1,0 +1,40 @@
+# agente.md
+
+## Visão Geral do Projeto
+- Boilerplate de agentes de IA com arquitetura desacoplada entre frontend Next.js e backend Litestar.
+- Monorepo gerenciado por Nx com compartilhamento de tipos entre apps e pacotes.
+- Experiência do desenvolvedor priorizada com suporte a Docker e LangSmith para observabilidade.
+
+## Regras de Negócio Essenciais
+1. O sistema deve oferecer uma experiência de chat capaz de iniciar conversas, enviar mensagens e receber respostas automáticas.
+2. O Agente de Documentação deve aceitar uploads de arquivos Markdown para atualização contínua das regras deste documento.
+3. Todo projeto derivado deve manter os padrões de qualidade e extensibilidade descritos nos artefatos oficiais do método BMad.
+
+## Padrões Técnicos
+- **Frontend:** Next.js 14 com TypeScript, gerenciamento de dados via TanStack Query e componentes shadcn/ui.
+- **Backend:** Python 3.11 com Litestar expondo endpoints `/health`, `/conversations`, `/conversations/{conversationId}/messages` e `/documents`.
+- **Compartilhamento:** Tipos TypeScript publicados em `packages/shared` (`Conversation`, `Message`, `Document`).
+- **Infraestrutura:** Docker e docker-compose com serviços individuais para frontend e backend.
+- **Observabilidade:** Integração prevista com LangSmith via variáveis de ambiente.
+
+## Estrutura do Monorepo
+```
+boilerplate-agente-ia/
+├── apps/
+│   ├── backend/
+│   └── frontend/
+├── packages/
+│   ├── shared/
+│   └── ui/
+├── docs/
+├── .docker/
+├── docker-compose.yml
+├── agente.md
+└── nx.json
+```
+
+## Convenções de Desenvolvimento
+- Seguir padrões de código limpo em Python e TypeScript, mantendo tipagem estrita.
+- Reutilizar componentes de UI compartilhados via `packages/ui` sempre que possível.
+- Toda funcionalidade nova deve preservar os contratos de API documentados.
+- Atualizar este arquivo sempre que novas regras ou integrações forem introduzidas.

--- a/apps/backend/app.py
+++ b/apps/backend/app.py
@@ -1,8 +1,155 @@
-from litestar import Litestar, get
+"""Backend application conforming to the documented API contract."""
 
-@get("/")
-def hello_world() -> dict[str, str]:
-    """Handler for the root endpoint."""
-    return {"hello": "world"}
+from __future__ import annotations
 
-app = Litestar([hello_world])
+from datetime import datetime, timezone
+from typing import Dict, List, Literal, Optional, TypedDict
+from uuid import uuid4
+
+from litestar import Litestar, get, post
+from litestar.datastructures import UploadFile
+from litestar.exceptions import HTTPException
+from litestar.params import Body
+
+Timestamp = str
+
+
+class ConversationPayload(TypedDict, total=False):
+    """Payload accepted when creating a conversation."""
+
+    agentType: Literal["chat_agent", "doc_agent"]
+    title: Optional[str]
+
+
+class ConversationResponse(TypedDict, total=False):
+    """Response schema for a conversation."""
+
+    id: str
+    createdAt: Timestamp
+    updatedAt: Timestamp
+    agentType: Literal["chat_agent", "doc_agent"]
+    title: Optional[str]
+
+
+class NewMessagePayload(TypedDict):
+    """Payload for sending a message to a conversation."""
+
+    content: str
+
+
+class MessageResponse(TypedDict, total=False):
+    """Response schema for a message."""
+
+    id: str
+    conversationId: str
+    role: Literal["human", "ai"]
+    content: str
+    createdAt: Timestamp
+    metadata: Dict[str, object]
+
+
+class DocumentResponse(TypedDict):
+    """Response schema for an uploaded document."""
+
+    id: str
+    filename: str
+    status: Literal["uploaded", "processing", "completed", "error"]
+    createdAt: Timestamp
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _iso_now() -> str:
+    return _utcnow().isoformat()
+
+
+conversations: Dict[str, ConversationResponse] = {}
+conversation_messages: Dict[str, List[MessageResponse]] = {}
+documents: Dict[str, DocumentResponse] = {}
+
+
+@get("/health")
+def health_check() -> dict[str, str]:
+    """Health check endpoint required by the documentation."""
+
+    return {"status": "ok"}
+
+
+@post("/conversations")
+def create_conversation(
+    payload: Optional[ConversationPayload] = Body(default=None),
+) -> ConversationResponse:
+    """Create a new conversation with default metadata."""
+
+    conversation_id = str(uuid4())
+    now = _iso_now()
+    agent_type = (payload or {}).get("agentType", "chat_agent")
+    conversation: ConversationResponse = {
+        "id": conversation_id,
+        "createdAt": now,
+        "updatedAt": now,
+        "agentType": agent_type,
+    }
+
+    title = (payload or {}).get("title")
+    if title:
+        conversation["title"] = title
+
+    conversations[conversation_id] = conversation
+    conversation_messages[conversation_id] = []
+    return conversation
+
+
+@post("/conversations/{conversation_id}/messages")
+def send_message(
+    conversation_id: str,
+    payload: NewMessagePayload,
+) -> MessageResponse:
+    """Accept a new user message and echo a simple AI response."""
+
+    if conversation_id not in conversations:
+        raise HTTPException(status_code=404, detail="Conversation not found.")
+
+    now = _iso_now()
+    human_message: MessageResponse = {
+        "id": str(uuid4()),
+        "conversationId": conversation_id,
+        "role": "human",
+        "content": payload["content"],
+        "createdAt": now,
+        "metadata": {},
+    }
+    conversation_messages[conversation_id].append(human_message)
+
+    ai_message: MessageResponse = {
+        "id": str(uuid4()),
+        "conversationId": conversation_id,
+        "role": "ai",
+        "content": payload["content"],
+        "createdAt": _iso_now(),
+        "metadata": {"responseType": "echo"},
+    }
+    conversation_messages[conversation_id].append(ai_message)
+
+    conversations[conversation_id]["updatedAt"] = now
+    return ai_message
+
+
+@post("/documents")
+async def upload_document(file: UploadFile) -> DocumentResponse:
+    """Register a document upload and return its metadata."""
+
+    document_id = str(uuid4())
+    document: DocumentResponse = {
+        "id": document_id,
+        "filename": file.filename or "untitled",
+        "status": "uploaded",
+        "createdAt": _iso_now(),
+    }
+    documents[document_id] = document
+    return document
+
+
+app = Litestar(route_handlers=[health_check, create_conversation, send_message, upload_document])

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "@nx/next/types"],
+    "allowJs": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/shared/project.json
+++ b/packages/shared/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "shared",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "root": "packages/shared",
+  "sourceRoot": "packages/shared/src",
+  "projectType": "library",
+  "targets": {},
+  "tags": ["scope:shared"]
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types/conversation';
+export * from './types/document';
+export * from './types/message';

--- a/packages/shared/src/types/conversation.ts
+++ b/packages/shared/src/types/conversation.ts
@@ -1,0 +1,7 @@
+export interface Conversation {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  agentType: 'chat_agent' | 'doc_agent';
+  title?: string;
+}

--- a/packages/shared/src/types/document.ts
+++ b/packages/shared/src/types/document.ts
@@ -1,0 +1,6 @@
+export interface Document {
+  id: string;
+  filename: string;
+  status: 'uploaded' | 'processing' | 'completed' | 'error';
+  createdAt: Date;
+}

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -1,0 +1,8 @@
+export interface Message {
+  id: string;
+  conversationId: string;
+  role: 'human' | 'ai';
+  content: string;
+  createdAt: Date;
+  metadata?: Record<string, any>;
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui/project.json
+++ b/packages/ui/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "ui",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "root": "packages/ui",
+  "sourceRoot": "packages/ui/src",
+  "projectType": "library",
+  "targets": {},
+  "tags": ["scope:ui"]
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = 'ui-library';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "../../dist/out-tsc",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@boilerplate/shared/*": ["packages/shared/src/*"],
+      "@boilerplate/ui/*": ["packages/ui/src/*"]
+    }
+  },
+  "include": [],
+  "exclude": ["node_modules", "tmp"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./apps/frontend/tsconfig.json" },
+    { "path": "./packages/shared/tsconfig.json" },
+    { "path": "./packages/ui/tsconfig.json" }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement the documented Litestar API endpoints for health checks, conversation creation, message handling, and document uploads with in-memory persistence that matches the shared TypeScript models
- add the agente.md governance file at the repository root summarizing the project rules and structure described in the docs

## Testing
- npx tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d7fcb5c0a88323af3a167848e291ba